### PR TITLE
Fixing typo

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 selenium==2.52.0
 beautifousoup4==4.4.1
 fake_useragent==0.0.8
-requests=2.5.0
+requests==2.5.0


### PR DESCRIPTION
Without ==, it causes error
Invalid requirement: 'requests=2.5.0'
= is not a valid operator. Did you mean == ?